### PR TITLE
fix(auth): dédupliquer les refreshes de token concurrents

### DIFF
--- a/tests/utils/authenticator.test.ts
+++ b/tests/utils/authenticator.test.ts
@@ -150,6 +150,38 @@ describe('Authenticator', () => {
     })
   })
 
+  describe('déduplication des refreshes concurrents', () => {
+    beforeEach(() => jest.clearAllMocks())
+
+    it("ne fait qu'un seul appel Keycloak pour N requêtes parallèles avec le même token", async () => {
+      // Given
+      const jwt = {
+        ...jwtFixture(),
+        refreshToken: 'refresh-concurrent',
+        expiresAtTimestamp: DateTime.now().minus({ second: 60 }).toMillis(),
+      }
+      ;(fetchJson as jest.Mock).mockResolvedValue({
+        content: {
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expires_in: 300,
+        },
+      })
+
+      // When — 3 appels parallèles avec le même refreshToken
+      const [r1, r2, r3] = await Promise.all([
+        handleJWTAndRefresh({ jwt }),
+        handleJWTAndRefresh({ jwt }),
+        handleJWTAndRefresh({ jwt }),
+      ])
+
+      // Then — un seul appel HTTP et résultats identiques
+      expect(fetchJson).toHaveBeenCalledTimes(1)
+      expect(r1).toEqual(r2)
+      expect(r2).toEqual(r3)
+    })
+  })
+
   describe('conseiller autre', () => {
     let accessToken: string
     let refreshToken: string
@@ -335,10 +367,11 @@ const accountFixture = (params: {
   scope: 'openid email profile',
 })
 
-const jwtFixture = (): JWT => ({
+const jwtFixture = (overrides?: Partial<JWT>): JWT => ({
   name: 'toto tata',
   sub: '448092da-4ad7-4fcf-8ff5-a303f30ea109',
   iat: 1638434437,
   exp: 1641026437,
   jti: 'efe3dae2-c2a1-4ac7-a0a2-1fe6cd0c8723',
+  ...overrides,
 })

--- a/utils/auth/authenticator.ts
+++ b/utils/auth/authenticator.ts
@@ -20,6 +20,8 @@ export const RefreshAccessTokenError = 'RefreshAccessTokenError'
 
 const issuerPrefix = process.env.KEYCLOAK_ISSUER
 
+const pendingRefreshes = new Map<string, Promise<HydratedJWT>>()
+
 export async function handleJWTAndRefresh({
   jwt,
   account,
@@ -37,10 +39,18 @@ export async function handleJWTAndRefresh({
       })
     : false
 
-  if (tokenIsExpired) {
-    return refreshAccessToken(hydratedJWT)
+  if (!tokenIsExpired) return hydratedJWT
+
+  const key = hydratedJWT.refreshToken
+  if (!key) return refreshAccessToken(hydratedJWT)
+
+  if (!pendingRefreshes.has(key)) {
+    const promise = refreshAccessToken(hydratedJWT).finally(() =>
+      pendingRefreshes.delete(key)
+    )
+    pendingRefreshes.set(key, promise)
   }
-  return hydratedJWT
+  return pendingRefreshes.get(key)!
 }
 
 async function hydrateJwtAtFirstSignin(
@@ -65,7 +75,7 @@ async function hydrateJwtAtFirstSignin(
   }
 }
 
-async function refreshAccessToken(jwt: HydratedJWT) {
+async function refreshAccessToken(jwt: HydratedJWT): Promise<HydratedJWT> {
   try {
     const refreshedTokens = await fetchRefreshedTokens(jwt.refreshToken)
 
@@ -76,7 +86,7 @@ async function refreshAccessToken(jwt: HydratedJWT) {
     return {
       ...jwt,
       accessToken: refreshedTokens.access_token,
-      refreshToken: refreshedTokens.refresh_token ?? jwt.refreshToken, // Garde l'ancien refresh_token
+      refreshToken: refreshedTokens.refresh_token ?? jwt.refreshToken,
       expiresAtTimestamp: expiresAtMs,
     }
   } catch (_error) {


### PR DESCRIPTION
Plusieurs Server Components parallèles voyaient le même token expiré et lançaient chacun un refresh. Keycloak invalide le refresh token après le premier usage → les suivants reçoivent 400 Bad Request → logout.

Fix : Map par refreshToken pour partager une seule Promise de refresh entre toutes les requêtes concurrentes.