### PR TITLE
fix(security): bump websocket-driver to 0.7.5 (GHSA-xv26-6w52-cph6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "svgo": ">=3.3.3",
     "protobufjs": "^7.6.1",
     "@grpc/grpc-js": ">=1.9.16",
-    "webpack-bundle-analyzer/ws": "^7.5.11"
+    "webpack-bundle-analyzer/ws": "^7.5.11",
+    "websocket-driver": ">=0.7.5"
   },
   "comments": {
     "resolutions": {
@@ -104,7 +105,8 @@
       "tar": "CVE-2026-23745 - À retirer quand tar (transitif) >= 7.5.4",
       "protobufjs": "GHSA-xq3m-2v4x-88gg / GHSA-66ff-xgx4-vchm / GHSA-75px-5xx7-5xc7 / GHSA-jvwf-75h9-cwgg / GHSA-685m-2w69-288q / GHSA-wcpc-wj8m-hjx6 - À retirer quand @grpc/proto-loader (transitif) dépend de protobufjs >= 7.6.1",
       "@grpc/grpc-js": "GHSA-5375-pq7m-f5r2 / GHSA-99f4-grh7-6pcq - À retirer quand @firebase/firestore (transitif via firebase) dépend de @grpc/grpc-js >= 1.9.16",
-      "webpack-bundle-analyzer/ws": "GHSA-96hv-2xvq-fx4p - À retirer quand webpack-bundle-analyzer (transitif) dépend de ws >= 7.5.11"
+      "webpack-bundle-analyzer/ws": "GHSA-96hv-2xvq-fx4p - À retirer quand webpack-bundle-analyzer (transitif) dépend de ws >= 7.5.11",
+      "websocket-driver": "GHSA-xv26-6w52-cph6 - À retirer quand faye-websocket (transitif via @firebase/database) dépend de websocket-driver >= 0.7.5"
     }
   },
   "browser": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12744,14 +12744,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"websocket-driver@npm:>=0.5.1":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+"websocket-driver@npm:>=0.7.5":
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10c0/5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
+  checksum: 10c0/843a3c9f529ce07f2721829f70f62986247525ab22625e857b69da13dc90967bacfe57b85e196801b565cd797e309ddd5b06fa8435732e34e8a8ab6201d7abed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ajout d'une résolution websocket-driver >= 0.7.5 pour corriger la CVE critique GHSA-xv26-6w52-cph6 (corruption de message via abus des headers de longueur de protocole), tirée en transitif via @firebase/database -> faye-websocket.